### PR TITLE
Change to how databuilders initially execute tasks

### DIFF
--- a/fms_sdg/base/databuilder.py
+++ b/fms_sdg/base/databuilder.py
@@ -121,6 +121,13 @@ class DataBuilder(ABC):
                     setattr(self, obj_name, obj)
                     (self._generators if i == 0 else self._validators).append(obj)
 
+    def call_with_task_list(self, request_idx: int, tasks: List[SdgTask]):
+        # default behavior is to simply extract the seed / machine generated data and pass to data builder
+        data_pool = [e for task in tasks for e in (task.seed_data + task.machine_data)]
+        args = [request_idx, data_pool]
+        kwargs = dict()
+        return self(*args, **kwargs)
+
     def __call__(
         self,
         request_idx: int,

--- a/fms_sdg/databuilders/nl2sql/generate.py
+++ b/fms_sdg/databuilders/nl2sql/generate.py
@@ -44,11 +44,8 @@ class Nl2SqlDataBuilder(DataBuilder):
 
     def __call__(
         self,
-        request_idx: int,
         instruction_data: List[SqlSdgData],
     ) -> Tuple[List[InstructLabSdgData], int]:
-        # NOTE: this not used in the context of sqlsdg
-        _ = request_idx
 
         outputs: List[InstructLabSdgData] = []
         discarded: int = 0
@@ -131,3 +128,9 @@ class Nl2SqlDataBuilder(DataBuilder):
                     discarded += 1
         sdg_logger.info("Data generation completed.")
         return outputs, discarded
+
+    def call_with_task_list(self, request_idx: int, tasks: List[SdgTask]):
+        # this data builder outputs data in a different format than the input, so only the original seed data should be used
+        _ = request_idx
+        data_pool = [e for task in tasks for e in task.seed_data]
+        return self(data_pool)

--- a/fms_sdg/generate_data.py
+++ b/fms_sdg/generate_data.py
@@ -129,13 +129,8 @@ def generate_data(
 
             iter_discarded = 0
 
-            data_pool = [
-                e for task in tasks for e in (task.seed_data + task.machine_data)
-            ]
-
-            filtered_data, discarded = data_builder(
-                request_idx,
-                data_pool,
+            filtered_data, discarded = data_builder.call_with_task_list(
+                request_idx, tasks
             )
             for task in tasks:
                 new_data = [fid for fid in filtered_data if fid.task_name == task.name]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/foundation-model-stack/fms-sdg/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #ISSUE_NUMBER

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it

This allows the calling of data builders on task objects to be separate from the main execution of a data builder

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility
