### PR TITLE
Lazy logging

### DIFF
--- a/fms_sdg/base/databuilder.py
+++ b/fms_sdg/base/databuilder.py
@@ -90,6 +90,9 @@ class DataBuilder(ABC):
             # user may not define a generator / validator
             if info_src is not None:
                 for obj_name, obj_config in info_src.items():
+                    sdg_logger.debug(
+                        "Initializing object %s with config %s", obj_name, obj_config
+                    )
                     obj = (get_generator if i == 0 else get_validator)(
                         obj_config[TYPE_KEY]
                     )(obj_name, obj_config)

--- a/fms_sdg/base/databuilder.py
+++ b/fms_sdg/base/databuilder.py
@@ -20,9 +20,9 @@ class DataBuilderConfig(dict):
     generators: Optional[Union[str, list]] = None
     validators: Optional[Union[str, list]] = None
     generation_kwargs: Optional[dict] = None
-    metadata: Optional[dict] = (
-        None  # by default, not used in the code. allows for users to pass arbitrary info to data builders
-    )
+    metadata: Optional[
+        dict
+    ] = None  # by default, not used in the code. allows for users to pass arbitrary info to data builders
 
     def __post_init__(self) -> None:
         if self.generation_kwargs is not None:
@@ -100,7 +100,7 @@ class DataBuilder(ABC):
                     if lm_cache is not None and isinstance(obj, LMGenerator):
                         sdg_logger.info(
                             "Using cache at %s",
-                            lm_cache + '_rank' + str(obj.rank) + '.db'
+                            lm_cache + "_rank" + str(obj.rank) + ".db",
                         )
                         obj = CachingLM(
                             obj,

--- a/fms_sdg/base/databuilder.py
+++ b/fms_sdg/base/databuilder.py
@@ -99,7 +99,8 @@ class DataBuilder(ABC):
 
                     if lm_cache is not None and isinstance(obj, LMGenerator):
                         sdg_logger.info(
-                            f"Using cache at {lm_cache + '_rank' + str(obj.rank) + '.db'}"
+                            "Using cache at %s",
+                            lm_cache + '_rank' + str(obj.rank) + '.db'
                         )
                         obj = CachingLM(
                             obj,

--- a/fms_sdg/databuilders/__init__.py
+++ b/fms_sdg/databuilders/__init__.py
@@ -123,7 +123,9 @@ class DataBuilderIndex:
 
                 if len(self._builder_index[builder_name]) > 2:
                     sdg_logger.warning(
-                        f"Multiple overriding configuration files detected for data builder {builder_name}. By default, configurations will be merged."
+                        "Multiple overriding configuration files detected for data builder %s. "
+                        "By default, configurations will be merged.",
+                        builder_name
                     )
 
         if os.path.isfile(builder_path):

--- a/fms_sdg/databuilders/__init__.py
+++ b/fms_sdg/databuilders/__init__.py
@@ -125,7 +125,7 @@ class DataBuilderIndex:
                     sdg_logger.warning(
                         "Multiple overriding configuration files detected for data builder %s. "
                         "By default, configurations will be merged.",
-                        builder_name
+                        builder_name,
                     )
 
         if os.path.isfile(builder_path):

--- a/fms_sdg/databuilders/api/generate.py
+++ b/fms_sdg/databuilders/api/generate.py
@@ -73,9 +73,11 @@ class ApiDataBuilder(DataBuilder):
         # return
         post_process_duration = time.time() - post_process_start
         sdg_logger.debug(
-            f"Request {request_idx} took {request_duration:.2f}s, "
-            f"post-processing took {post_process_duration:.2f}s, "
-            f"discarded {wf_discarded + rouge_discarded} instances"
+            "Request %s took %.2fs, post-processing took %.2fs, discarded %s instances",
+            request_idx,
+            request_duration,
+            post_process_duration,
+            wf_discarded + rouge_discarded,
         )
 
         return outputs

--- a/fms_sdg/databuilders/nl2sql/generate.py
+++ b/fms_sdg/databuilders/nl2sql/generate.py
@@ -65,7 +65,8 @@ class Nl2SqlDataBuilder(DataBuilder):
                 **data_generation_schema_dict
             )
             sdg_logger.info(
-                f"Running generation pipeline with data configuration: {data_generation_schema.model_dump_json(indent=2)}"
+                "Running generation pipeline with data configuration: %s",
+                data_generation_schema.model_dump_json(indent=2)
             )
             prompting_pipeline = SQLDataGenerationPromptingPipeline()
             instances = prompting_pipeline.run(

--- a/fms_sdg/databuilders/nl2sql/generate.py
+++ b/fms_sdg/databuilders/nl2sql/generate.py
@@ -58,15 +58,15 @@ class Nl2SqlDataBuilder(DataBuilder):
             # NOTE: here we rely on the fact that all the relevant information is in the key "task_info".
             # We just need to add some "task_description" as it is redacted by data configuration loading.
             data_generation_schema_dict = asdict(instruction_data_item)
-            data_generation_schema_dict["task_description"] = (
-                instruction_data_item.task_description
-            )
+            data_generation_schema_dict[
+                "task_description"
+            ] = instruction_data_item.task_description
             data_generation_schema = SQLDataGenerationSchema(
                 **data_generation_schema_dict
             )
             sdg_logger.info(
                 "Running generation pipeline with data configuration: %s",
-                data_generation_schema.model_dump_json(indent=2)
+                data_generation_schema.model_dump_json(indent=2),
             )
             prompting_pipeline = SQLDataGenerationPromptingPipeline()
             instances = prompting_pipeline.run(

--- a/fms_sdg/databuilders/simple/generate.py
+++ b/fms_sdg/databuilders/simple/generate.py
@@ -92,8 +92,10 @@ class SimpleInstructDataBuilder(DataBuilder):
 
         post_process_duration = time.time() - post_process_start
         sdg_logger.debug(
-            f"Request {request_idx} took {request_duration:.2f}s, "
-            f"post-processing took {post_process_duration:.2f}s"
+            "Request %s took %.2fs, post-processing took %.2fs",
+            request_idx,
+            request_duration,
+            post_process_duration
         )
 
         # now we assess and filter with rouge
@@ -118,7 +120,9 @@ class SimpleInstructDataBuilder(DataBuilder):
 
         assess_duration = time.time() - assess_start
         sdg_logger.debug(
-            f"Assessing generated samples took {assess_duration:.2f}s, discarded {discarded} instances"
+            "Assessing generated samples took %.2fs, discarded %s instances",
+            assess_duration,
+            discarded
         )
 
         return outputs

--- a/fms_sdg/databuilders/simple/generate.py
+++ b/fms_sdg/databuilders/simple/generate.py
@@ -95,7 +95,7 @@ class SimpleInstructDataBuilder(DataBuilder):
             "Request %s took %.2fs, post-processing took %.2fs",
             request_idx,
             request_duration,
-            post_process_duration
+            post_process_duration,
         )
 
         # now we assess and filter with rouge
@@ -122,7 +122,7 @@ class SimpleInstructDataBuilder(DataBuilder):
         sdg_logger.debug(
             "Assessing generated samples took %.2fs, discarded %s instances",
             assess_duration,
-            discarded
+            discarded,
         )
 
         return outputs

--- a/fms_sdg/databuilders/simple/utils.py
+++ b/fms_sdg/databuilders/simple/utils.py
@@ -137,12 +137,7 @@ def encode_prompt(prompt_instructions: List[InstructLabSdgData], prompt: str):
 
     # pylint: disable=unused-variable
     for idx, task_obj in enumerate(prompt_instructions):
-        (
-            instruction,
-            prompt_input,
-            prompt_output,
-            taxonomy_path,
-        ) = (
+        (instruction, prompt_input, prompt_output, taxonomy_path,) = (
             task_obj.instruction,
             task_obj.input,
             task_obj.output,
@@ -199,7 +194,7 @@ def post_process_gpt3_response(num_prompt_instructions, response):
         if any(find_word_in_string(word, inst) for word in _WORD_DENYLIST):
             sdg_logger.info(
                 "Discarded instruction (contained a word from the denylist): %s",
-                repr(splitted_data)
+                repr(splitted_data),
             )
             discarded += 1
             continue
@@ -210,7 +205,7 @@ def post_process_gpt3_response(num_prompt_instructions, response):
         if inst.startswith("Write a program"):
             sdg_logger.info(
                 "Discarded instruction (began with 'Write a program'): %s",
-                repr(splitted_data)
+                repr(splitted_data),
             )
             discarded += 1
             continue
@@ -218,7 +213,7 @@ def post_process_gpt3_response(num_prompt_instructions, response):
         if inst[0] in string.punctuation:
             sdg_logger.info(
                 "Discarded instruction (began with punctuation): %s",
-                repr(splitted_data)
+                repr(splitted_data),
             )
             discarded += 1
             continue

--- a/fms_sdg/databuilders/simple/utils.py
+++ b/fms_sdg/databuilders/simple/utils.py
@@ -180,7 +180,7 @@ def post_process_gpt3_response(num_prompt_instructions, response):
         splitted_data = re.split(r"\*\*\s+(Instruction|Input|Output):?", inst)
         if len(splitted_data) != 7:
             sdg_logger.info(
-                "Discarded instruction (didn't match expected format): " + repr(inst),
+                "Discarded instruction (didn't match expected format): %s", repr(inst)
             )
             discarded += 1
             continue
@@ -191,15 +191,15 @@ def post_process_gpt3_response(num_prompt_instructions, response):
         # filter out too short or too long instructions
         if len(inst.split()) <= 3 or len(inst.split()) > 150:
             sdg_logger.info(
-                "Discarded instruction (wrong number of words): " + repr(splitted_data),
+                "Discarded instruction (wrong number of words): %s", repr(splitted_data)
             )
             discarded += 1
             continue
         # filter based on keywords that are not suitable for language models.
         if any(find_word_in_string(word, inst) for word in _WORD_DENYLIST):
             sdg_logger.info(
-                "Discarded instruction (contained a word from the denylist): "
-                + repr(splitted_data),
+                "Discarded instruction (contained a word from the denylist): %s",
+                repr(splitted_data)
             )
             discarded += 1
             continue
@@ -209,23 +209,23 @@ def post_process_gpt3_response(num_prompt_instructions, response):
         # NOTE: this is not a comprehensive filtering for all programming instructions.
         if inst.startswith("Write a program"):
             sdg_logger.info(
-                "Discarded instruction (began with 'Write a program'): "
-                + repr(splitted_data),
+                "Discarded instruction (began with 'Write a program'): %s",
+                repr(splitted_data)
             )
             discarded += 1
             continue
         # filter those starting with punctuation
         if inst[0] in string.punctuation:
             sdg_logger.info(
-                "Discarded instruction (began with punctuation): "
-                + repr(splitted_data),
+                "Discarded instruction (began with punctuation): %s",
+                repr(splitted_data)
             )
             discarded += 1
             continue
         # filter those starting with non-english character
         if not inst[0].isascii():
             sdg_logger.info(
-                "Discarded instruction(began with non-ascii): " + repr(splitted_data),
+                "Discarded instruction(began with non-ascii): %s", repr(splitted_data)
             )
             discarded += 1
             continue

--- a/fms_sdg/generate_data.py
+++ b/fms_sdg/generate_data.py
@@ -52,6 +52,7 @@ def generate_data(
         include_builder_path=include_builder_path,
     )
     builder_names = builder_index.match_builders(builder_list)
+    sdg_logger.debug("All builders: %s", builder_names)
     for builder in [
         builder for builder in builder_list if builder not in builder_names
     ]:
@@ -83,6 +84,7 @@ def generate_data(
             _, builder_cfg = builder_cfg
             if builder_cfg is None:
                 continue
+        sdg_logger.debug("Builder config for %s: %s", builder_name, builder_cfg)
 
         # builder_dir is stored in the first builder_info in the list
         utils.import_builder(

--- a/fms_sdg/generate_data.py
+++ b/fms_sdg/generate_data.py
@@ -154,7 +154,7 @@ def generate_data(
 
             sdg_logger.info(
                 "Generated %s data",
-                sum([len(task.machine_data) for task in tasks + completed_tasks])
+                sum([len(task.machine_data) for task in tasks + completed_tasks]),
             )
 
         # TODO: cleanup

--- a/fms_sdg/generate_data.py
+++ b/fms_sdg/generate_data.py
@@ -120,7 +120,7 @@ def generate_data(
             if os.path.exists(task.output_path):
                 task.load_data()
                 sdg_logger.debug(
-                    f"Loaded {len(task.machine_data)} machine-generated data"
+                    "Loaded %s machine-generated data", len(task.machine_data)
                 )
 
         completed_tasks = [task for task in tasks if task.is_complete()]
@@ -153,7 +153,8 @@ def generate_data(
             tasks = [task for task in tasks if task not in completed_tasks]
 
             sdg_logger.info(
-                f"Generated {sum([len(task.machine_data) for task in tasks + completed_tasks])} data"
+                "Generated %s data",
+                sum([len(task.machine_data) for task in tasks + completed_tasks])
             )
 
         # TODO: cleanup
@@ -162,4 +163,4 @@ def generate_data(
     progress_bar.close()
 
     generate_duration = time.time() - generate_start
-    sdg_logger.info(f"Generation took {generate_duration:.2f}s")
+    sdg_logger.info("Generation took %.2fs", generate_duration)

--- a/fms_sdg/generators/llm.py
+++ b/fms_sdg/generators/llm.py
@@ -189,7 +189,9 @@ class CachingLM:
             warned = False
             # figure out which ones are cached and which ones are new
             sdg_logger.info(
-                f"Loading '{attr}' responses from cache '{self.cache_db}' where possible..."
+                "Loading '%s' responses from cache '%s' where possible...",
+                attr,
+                self.cache_db,
             )
             for req in tqdm(requests, desc="Checking cached requests"):
                 hsh = hash_args(attr, req)
@@ -201,7 +203,9 @@ class CachingLM:
                     # (else every "randomly sampled" generation would be identical for repeats > 1).
                     if not warned:
                         sdg_logger.warning(
-                            f"Arguments to lm.generate_batch() '{req.kwargs}' include non-deterministic sampling. Caching will not be performed for such requests."
+                            "Arguments to lm.generate_batch() '%s' include non-deterministic "
+                            "sampling. Caching will not be performed for such requests.",
+                            req.kwargs
                         )
                         warned = True
                     res.append(None)
@@ -215,7 +219,9 @@ class CachingLM:
                     remaining_reqs.append(req)
 
             sdg_logger.info(
-                f"Cached requests: {len(requests) - len(remaining_reqs)}, Requests remaining: {len(remaining_reqs)}"
+                "Cached requests: %s, Requests remaining: %s",
+                len(requests) - len(remaining_reqs),
+                len(remaining_reqs)
             )
 
             # actually run the LM on the requests that do not have cached results

--- a/fms_sdg/generators/llm.py
+++ b/fms_sdg/generators/llm.py
@@ -205,7 +205,7 @@ class CachingLM:
                         sdg_logger.warning(
                             "Arguments to lm.generate_batch() '%s' include non-deterministic "
                             "sampling. Caching will not be performed for such requests.",
-                            req.kwargs
+                            req.kwargs,
                         )
                         warned = True
                     res.append(None)
@@ -221,7 +221,7 @@ class CachingLM:
             sdg_logger.info(
                 "Cached requests: %s, Requests remaining: %s",
                 len(requests) - len(remaining_reqs),
-                len(remaining_reqs)
+                len(remaining_reqs),
             )
 
             # actually run the LM on the requests that do not have cached results

--- a/fms_sdg/generators/utils.py
+++ b/fms_sdg/generators/utils.py
@@ -35,9 +35,6 @@ import time
 import torch
 import transformers
 
-# Local
-from fms_sdg.utils import sdg_logger
-
 
 class MultiTokenEOSCriteria(transformers.StoppingCriteria):
     """Criteria to stop on the specified multi-token sequence."""

--- a/fms_sdg/generators/vllm.py
+++ b/fms_sdg/generators/vllm.py
@@ -123,7 +123,9 @@ class vLLMGenerator(LMGenerator):
                 "0.3.3"
             ), "data_parallel is only compatible with vllm < v0.3.3."
             sdg_logger.warning(
-                "You might experience occasional issues with model weight downloading when data_parallel is in use. To ensure stable performance, run with data_parallel_size=1 until the weights are downloaded and cached."
+                "You might experience occasional issues with model weight downloading "
+                "when data_parallel is in use. To ensure stable performance, run with "
+                "data_parallel_size=1 until the weights are downloaded and cached."
             )
             self.model_args["worker_use_ray"] = True
             self.batch_size = "auto"
@@ -145,7 +147,8 @@ class vLLMGenerator(LMGenerator):
         self.custom_prefix_token_id = prefix_token_id
         if prefix_token_id is not None:
             sdg_logger.info(
-                f"Loglikelihood prefix token id used in evaluation: {self.prefix_token_id}"
+                "Loglikelihood prefix token id used in evaluation: %s",
+                self.prefix_token_id
             )
 
         self._max_gen_toks = max_gen_toks

--- a/fms_sdg/generators/vllm.py
+++ b/fms_sdg/generators/vllm.py
@@ -146,7 +146,7 @@ class vLLMGenerator(LMGenerator):
         if prefix_token_id is not None:
             sdg_logger.info(
                 "Loglikelihood prefix token id used in evaluation: %s",
-                self.prefix_token_id
+                self.prefix_token_id,
             )
 
         self._max_gen_toks = max_gen_toks

--- a/fms_sdg/generators/vllm.py
+++ b/fms_sdg/generators/vllm.py
@@ -39,8 +39,6 @@ try:
 except ModuleNotFoundError:
     pass
 
-sdg_logger = sdg_logger
-
 
 # TODO: this can be made more efficient for our purposes by rewriting the async code ourselves
 @register_generator("vllm")

--- a/fms_sdg/utils.py
+++ b/fms_sdg/utils.py
@@ -11,10 +11,11 @@ import os
 # Third Party
 import yaml
 
+log_level = getattr(logging, os.getenv("LOG_LEVEL", "info").upper())
 logging.basicConfig(
     format="%(asctime)s,%(msecs)03d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s",
     datefmt="%Y-%m-%d:%H:%M:%S",
-    level=logging.INFO,
+    level=log_level,
 )
 sdg_logger = logging.getLogger("fms_sdg")
 

--- a/fms_sdg/utils.py
+++ b/fms_sdg/utils.py
@@ -271,7 +271,7 @@ def read_data_file(file_path: str):
         contents = load_yaml_config(file_path)
 
         if not contents:
-            sdg_logger.warn(f"Skipping {file_path} because it is empty!")
+            sdg_logger.warn("Skipping %s because it is empty!", file_path)
             return None
 
         if file_path.startswith("." + os.sep):

--- a/templates/databuilder/generate.py
+++ b/templates/databuilder/generate.py
@@ -11,7 +11,6 @@ from fms_sdg.base.instance import Instance
 from fms_sdg.base.registry import register_data_builder
 from fms_sdg.base.task import SdgTask
 from fms_sdg.generators.llm import LMGenerator
-from fms_sdg.utils import sdg_logger
 from fms_sdg.validators.rouge import RougeValidator
 
 

--- a/tests/databuilders/test_nl2sql.py
+++ b/tests/databuilders/test_nl2sql.py
@@ -1,4 +1,3 @@
-# Third-party
 # Third Party
 import pytest
 

--- a/tests/databuilders/test_nl2sql.py
+++ b/tests/databuilders/test_nl2sql.py
@@ -1,4 +1,5 @@
 # Third-party
+# Third Party
 import pytest
 
 # Local

--- a/tests/validators/test_nl2sql.py
+++ b/tests/validators/test_nl2sql.py
@@ -1,6 +1,6 @@
 # Local
-from fms_sdg.validators.nl2sql.sql_syntax_validator import SQLSyntaxValidator
 from fms_sdg.validators.nl2sql.sql_execution_validator import SQLExecutionValidator
+from fms_sdg.validators.nl2sql.sql_syntax_validator import SQLSyntaxValidator
 
 
 def test_sql_syntax_validator():


### PR DESCRIPTION
## What this PR does / why we need it

This PR updates two things about how `logging` is used in the package:

1. It allows the level for the `sdg_logger` to be set from the `LOG_LEVEL` env var
2. It updates all uses of `sdg_logger` to do lazy string interpolation

One of the main benefits of the python logging framework is the ability to defer the string operations to construct the full log message until the message is formatted. This allows more granular logging without the cost of many extra string operations since those operations will not be performed if the log level is disabled.

This does require use of the more archaic percent-encoding style of string formatting, but the performance gain (and general best practice) is worth the gorpiness!

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
